### PR TITLE
Add dedicated exchange rate page using Frankfurter API

### DIFF
--- a/exchange.html
+++ b/exchange.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>為替レート一覧 | Your App Name</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+    <script src="exchange.js" defer></script>
+</head>
+<body>
+    <header>
+        <h1>為替レート一覧</h1>
+        <p class="header-subtitle">
+            Frankfurter API（欧州中央銀行の公表レート）から取得した最新のUSD/JPYとEUR/JPYのレートです。
+        </p>
+        <nav>
+            <a href="index.html">トップページに戻る</a>
+        </nav>
+    </header>
+
+    <main>
+        <section>
+            <h2>主要通貨のレート</h2>
+            <p>
+                Frankfurterは営業日に1回更新されるため、このページでは1時間おきにレートを再取得します。
+            </p>
+
+            <div class="rates-meta">
+                <div class="rates-meta-item">
+                    <span class="rates-meta-label">データ日</span>
+                    <span class="rates-meta-value" id="ratesDataDate">—</span>
+                </div>
+                <div class="rates-meta-item">
+                    <span class="rates-meta-label">取得時刻</span>
+                    <span class="rates-meta-value" id="lastUpdated">—</span>
+                </div>
+                <button type="button" class="refresh-button" id="refreshRatesButton">今すぐ更新</button>
+            </div>
+
+            <div class="rates-table-wrapper">
+                <table class="rates-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">通貨ペア</th>
+                            <th scope="col">レート</th>
+                            <th scope="col">レート更新日</th>
+                        </tr>
+                    </thead>
+                    <tbody id="ratesBody">
+                        <tr>
+                            <th scope="row">USD / JPY</th>
+                            <td>—</td>
+                            <td>—</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">EUR / JPY</th>
+                            <td>—</td>
+                            <td>—</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <p id="statusMessage" class="rates-status-message" role="status" aria-live="polite">
+                最新のレートを取得しています...
+            </p>
+
+            <p class="rates-footnote">
+                データソース: <a href="https://www.frankfurter.dev/docs/" target="_blank" rel="noopener noreferrer">Frankfurter API</a>
+            </p>
+        </section>
+    </main>
+
+    <footer>
+        &copy; 2024 Your App Name. All rights reserved.
+    </footer>
+</body>
+</html>

--- a/exchange.js
+++ b/exchange.js
@@ -1,0 +1,184 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const RATE_PAIRS = [
+        { base: 'USD', symbol: 'JPY' },
+        { base: 'EUR', symbol: 'JPY' },
+    ];
+    const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+    const ratesBody = document.getElementById('ratesBody');
+    const dataDateElement = document.getElementById('ratesDataDate');
+    const lastUpdatedElement = document.getElementById('lastUpdated');
+    const statusElement = document.getElementById('statusMessage');
+    const refreshButton = document.getElementById('refreshRatesButton');
+
+    if (!ratesBody || !lastUpdatedElement || !statusElement) {
+        return;
+    }
+
+    const numberFormatter = new Intl.NumberFormat('ja-JP', {
+        minimumFractionDigits: 4,
+        maximumFractionDigits: 4,
+    });
+    const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+        dateStyle: 'medium',
+        timeZone: 'Asia/Tokyo',
+    });
+    const dateTimeFormatter = new Intl.DateTimeFormat('ja-JP', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: 'Asia/Tokyo',
+    });
+
+    const formatRate = (rate) => numberFormatter.format(rate);
+    const formatDate = (dateString) => {
+        const date = new Date(`${dateString}T00:00:00Z`);
+        if (Number.isNaN(date.getTime())) {
+            return dateString;
+        }
+        return dateFormatter.format(date);
+    };
+    const formatDateTime = (date) => dateTimeFormatter.format(date);
+
+    const fetchPair = async ({ base, symbol }) => {
+        const url = `https://api.frankfurter.dev/v1/latest?base=${base}&symbols=${symbol}`;
+        const response = await fetch(url);
+
+        if (!response.ok) {
+            throw new Error(`Frankfurter API responded with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+        const rate = payload?.rates?.[symbol];
+
+        if (typeof rate !== 'number') {
+            throw new Error('Frankfurter API response did not include the expected rate.');
+        }
+
+        return {
+            base,
+            symbol,
+            rate,
+            date: payload.date,
+        };
+    };
+
+    const renderFallbackRows = () => {
+        ratesBody.innerHTML = '';
+        RATE_PAIRS.forEach(({ base, symbol }) => {
+            const row = document.createElement('tr');
+            row.classList.add('rates-row-error');
+
+            const pairCell = document.createElement('th');
+            pairCell.scope = 'row';
+            pairCell.textContent = `${base} / ${symbol}`;
+
+            const rateCell = document.createElement('td');
+            rateCell.textContent = '取得エラー';
+
+            const dateCell = document.createElement('td');
+            dateCell.textContent = '—';
+
+            row.append(pairCell, rateCell, dateCell);
+            ratesBody.appendChild(row);
+        });
+    };
+
+    let isUpdating = false;
+
+    const refreshRates = async () => {
+        if (isUpdating) {
+            return;
+        }
+
+        isUpdating = true;
+        statusElement.textContent = '最新のレートを取得しています...';
+
+        if (refreshButton) {
+            refreshButton.disabled = true;
+        }
+
+        const fetchTime = new Date();
+
+        try {
+            const results = await Promise.allSettled(RATE_PAIRS.map(fetchPair));
+
+            ratesBody.innerHTML = '';
+
+            let successCount = 0;
+            let failureCount = 0;
+            let latestDataDate = null;
+
+            results.forEach((result, index) => {
+                const { base, symbol } = RATE_PAIRS[index];
+                const row = document.createElement('tr');
+
+                const pairCell = document.createElement('th');
+                pairCell.scope = 'row';
+                pairCell.textContent = `${base} / ${symbol}`;
+                row.appendChild(pairCell);
+
+                const rateCell = document.createElement('td');
+                const dateCell = document.createElement('td');
+
+                if (result.status === 'fulfilled') {
+                    const { rate, date } = result.value;
+
+                    rateCell.textContent = formatRate(rate);
+                    dateCell.textContent = formatDate(date);
+
+                    if (!latestDataDate || date > latestDataDate) {
+                        latestDataDate = date;
+                    }
+
+                    successCount += 1;
+                } else {
+                    rateCell.textContent = '取得エラー';
+                    dateCell.textContent = '—';
+                    row.classList.add('rates-row-error');
+                    failureCount += 1;
+                    console.error(`Failed to fetch rate for ${base}/${symbol}`, result.reason);
+                }
+
+                row.append(rateCell, dateCell);
+                ratesBody.appendChild(row);
+            });
+
+            if (dataDateElement) {
+                dataDateElement.textContent = latestDataDate ? formatDate(latestDataDate) : '—';
+            }
+
+            lastUpdatedElement.textContent =
+                successCount > 0 ? formatDateTime(fetchTime) : '—';
+
+            if (failureCount === 0) {
+                statusElement.textContent = '最新のレートを取得しました。';
+            } else if (successCount === 0) {
+                statusElement.textContent = 'レートを取得できませんでした。時間をおいて再度お試しください。';
+            } else {
+                statusElement.textContent = '一部のレートを取得できませんでした。';
+            }
+        } catch (error) {
+            console.error('Unexpected error while updating rates', error);
+            renderFallbackRows();
+            lastUpdatedElement.textContent = '—';
+            if (dataDateElement) {
+                dataDateElement.textContent = '—';
+            }
+            statusElement.textContent = 'レートを取得できませんでした。時間をおいて再度お試しください。';
+        } finally {
+            if (refreshButton) {
+                refreshButton.disabled = false;
+            }
+            isUpdating = false;
+        }
+    };
+
+    if (refreshButton) {
+        refreshButton.addEventListener('click', () => {
+            refreshRates();
+        });
+    }
+
+    refreshRates();
+    setInterval(refreshRates, REFRESH_INTERVAL_MS);
+});

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
             <a href="#about">About</a>
             <a href="#privacy">Privacy</a>
             <a href="#contact">Contact</a>
+            <a href="exchange.html" target="_blank" rel="noopener noreferrer">為替一覧</a>
         </nav>
     </header>
 

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
         button.addEventListener('click', () => showTab(button.dataset.tab));
     });
 
-    document.querySelectorAll('header nav a').forEach((link) => {
+    document.querySelectorAll('header nav a[href^="#"]').forEach((link) => {
         link.addEventListener('click', () => showTab('overview'));
     });
 

--- a/styles.css
+++ b/styles.css
@@ -159,6 +159,116 @@ a {
     accent-color: var(--primary-dark);
 }
 
+.header-subtitle {
+    margin-top: 0.75rem;
+    font-weight: 300;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.rates-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    margin: 1.5rem 0 0.75rem;
+}
+
+.rates-meta-item {
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(138, 182, 255, 0.3);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 6px 18px rgba(138, 182, 255, 0.2);
+    min-width: 180px;
+}
+
+.rates-meta-label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--primary-dark);
+}
+
+.rates-meta-value {
+    display: block;
+    margin-top: 0.15rem;
+    font-size: 1.1rem;
+    font-weight: 700;
+}
+
+.refresh-button {
+    padding: 0.7rem 1.6rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--primary-dark);
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 8px 20px rgba(106, 156, 245, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.refresh-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px rgba(106, 156, 245, 0.45);
+}
+
+.refresh-button:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: 0 4px 12px rgba(138, 182, 255, 0.2);
+}
+
+.rates-table-wrapper {
+    margin-top: 1.25rem;
+    overflow-x: auto;
+    border-radius: 16px;
+    border: 1px solid rgba(138, 182, 255, 0.3);
+    box-shadow: 0 10px 25px rgba(138, 182, 255, 0.25);
+    background: rgba(255, 255, 255, 0.95);
+}
+
+.rates-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 320px;
+}
+
+.rates-table thead {
+    background: linear-gradient(135deg, var(--primary-light), var(--primary));
+    color: #fff;
+}
+
+.rates-table th,
+.rates-table td {
+    padding: 0.85rem 1.1rem;
+    text-align: left;
+    font-size: 0.95rem;
+}
+
+.rates-table tbody tr:nth-child(even) {
+    background: rgba(138, 182, 255, 0.08);
+}
+
+.rates-row-error td {
+    color: #d35454;
+    font-weight: 600;
+}
+
+.rates-status-message {
+    margin-top: 1rem;
+    font-weight: 500;
+    color: var(--primary-dark);
+}
+
+.rates-footnote {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    color: rgba(47, 58, 74, 0.8);
+}
+
 footer {
     text-align: center;
     padding: 1.5rem 1rem;
@@ -185,6 +295,20 @@ footer {
 
     section {
         padding: 1.75rem;
+    }
+
+    .rates-meta {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .rates-meta-item {
+        width: 100%;
+    }
+
+    .refresh-button {
+        width: 100%;
+        text-align: center;
     }
 }
     


### PR DESCRIPTION
## Summary
- add a navigation link that opens a new exchange rate overview in a separate tab
- build an exchange rates page that polls the Frankfurter API for USD/JPY and EUR/JPY once per hour and on demand
- extend shared styles to support the exchange rate page layout, status messaging, and controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8f2d7ccf0832791de7f3166ed001e