### PR TITLE
Add exchange rates tab with lazy-loaded module

### DIFF
--- a/exchange.html
+++ b/exchange.html
@@ -6,7 +6,6 @@
     <title>為替レート一覧 | Your App Name</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
-    <script src="exchange.js" defer></script>
 </head>
 <body>
     <header>
@@ -14,9 +13,6 @@
         <p class="header-subtitle">
             Frankfurter API（欧州中央銀行の公表レート）から取得した最新のUSD/JPYとEUR/JPYのレートです。
         </p>
-        <nav>
-            <a href="index.html">トップページに戻る</a>
-        </nav>
     </header>
 
     <main>
@@ -75,5 +71,11 @@
     <footer>
         &copy; 2024 Your App Name. All rights reserved.
     </footer>
+
+    <script type="module">
+        import { initializeExchangeRates } from './exchange.js';
+
+        initializeExchangeRates(document);
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,12 +11,6 @@
 <body>
     <header>
         <h1>Your App Name</h1>
-        <nav>
-            <a href="#about">About</a>
-            <a href="#privacy">Privacy</a>
-            <a href="#contact">Contact</a>
-            <a href="exchange.html" target="_blank" rel="noopener noreferrer">為替一覧</a>
-        </nav>
     </header>
 
     <main>
@@ -25,6 +19,7 @@
                 <div class="tab-buttons">
                     <button class="tab-button active" data-tab="overview">Overview</button>
                     <button class="tab-button" data-tab="statistics">Statistics</button>
+                    <button class="tab-button" data-tab="exchange">為替レート</button>
                 </div>
                 <div class="tab-content active" id="tab-overview">
                     <h2 id="about">About Us</h2>
@@ -91,6 +86,59 @@
                         <canvas id="normalDistributionChart" aria-label="Normal distribution chart" role="img"></canvas>
                     </div>
                 </div>
+                <div class="tab-content" id="tab-exchange">
+                    <h2>為替レート</h2>
+                    <p>
+                        Frankfurter API（欧州中央銀行の公表レート）から取得した最新のUSD/JPYとEUR/JPYのレートです。
+                    </p>
+                    <p>
+                        このタブを開くと最新のレートを取得し、1時間ごとに自動で更新します。
+                    </p>
+
+                    <div class="rates-meta">
+                        <div class="rates-meta-item">
+                            <span class="rates-meta-label">データ日</span>
+                            <span class="rates-meta-value" id="ratesDataDate">—</span>
+                        </div>
+                        <div class="rates-meta-item">
+                            <span class="rates-meta-label">取得時刻</span>
+                            <span class="rates-meta-value" id="lastUpdated">—</span>
+                        </div>
+                        <button type="button" class="refresh-button" id="refreshRatesButton">今すぐ更新</button>
+                    </div>
+
+                    <div class="rates-table-wrapper">
+                        <table class="rates-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">通貨ペア</th>
+                                    <th scope="col">レート</th>
+                                    <th scope="col">レート更新日</th>
+                                </tr>
+                            </thead>
+                            <tbody id="ratesBody">
+                                <tr>
+                                    <th scope="row">USD / JPY</th>
+                                    <td>—</td>
+                                    <td>—</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">EUR / JPY</th>
+                                    <td>—</td>
+                                    <td>—</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <p id="statusMessage" class="rates-status-message" role="status" aria-live="polite">
+                        最新のレートを取得しています...
+                    </p>
+
+                    <p class="rates-footnote">
+                        データソース: <a href="https://www.frankfurter.dev/docs/" target="_blank" rel="noopener noreferrer">Frankfurter API</a>
+                    </p>
+                </div>
             </div>
         </section>
     </main>
@@ -100,6 +148,6 @@
     </footer>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new tab on the landing page that hosts the exchange rate table and remove the now-unneeded header links
- lazy-load the exchange rate logic when the tab is activated so the page avoids navigation while keeping the main bundle light
- refactor the exchange rates script into an initializer that can be reused by the standalone page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8f61522b8832783f0bc4b9a6654e8