### PR TITLE
Add historical FX trends with daily change

### DIFF
--- a/exchange.html
+++ b/exchange.html
@@ -20,6 +20,7 @@
             <h2>主要通貨のレート</h2>
             <p>
                 Frankfurterは営業日に1回更新されるため、このページでは1時間おきにレートを再取得します。
+                過去2週間分の日次レートと前日比も下部で確認できます。
             </p>
 
             <div class="rates-meta">
@@ -56,6 +57,35 @@
                         </tr>
                     </tbody>
                 </table>
+            </div>
+
+            <div class="historical-section">
+                <h3>過去2週間の推移</h3>
+                <p class="historical-description">
+                    営業日のみ公表されるレートを日次で表示し、前日比（％）も確認できます。
+                </p>
+                <div class="rates-table-wrapper">
+                    <table class="rates-table historical-rates-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">日付</th>
+                                <th scope="col">USD / JPY</th>
+                                <th scope="col">前日比</th>
+                                <th scope="col">EUR / JPY</th>
+                                <th scope="col">前日比</th>
+                            </tr>
+                        </thead>
+                        <tbody id="historicalRatesBody">
+                            <tr>
+                                <th scope="row">—</th>
+                                <td>—</td>
+                                <td>—</td>
+                                <td>—</td>
+                                <td>—</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
 
             <p id="statusMessage" class="rates-status-message" role="status" aria-live="polite">

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
                     </p>
                     <p>
                         このタブを開くと最新のレートを取得し、1時間ごとに自動で更新します。
+                        過去2週間分の日次レートと前日比も確認できます。
                     </p>
 
                     <div class="rates-meta">
@@ -129,6 +130,35 @@
                                 </tr>
                             </tbody>
                         </table>
+                    </div>
+
+                    <div class="historical-section">
+                        <h3>過去2週間の推移</h3>
+                        <p class="historical-description">
+                            営業日のみ公表されるレートを日次で表示し、前日比（％）も確認できます。
+                        </p>
+                        <div class="rates-table-wrapper">
+                            <table class="rates-table historical-rates-table">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">日付</th>
+                                        <th scope="col">USD / JPY</th>
+                                        <th scope="col">前日比</th>
+                                        <th scope="col">EUR / JPY</th>
+                                        <th scope="col">前日比</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="historicalRatesBody">
+                                    <tr>
+                                        <th scope="row">—</th>
+                                        <td>—</td>
+                                        <td>—</td>
+                                        <td>—</td>
+                                        <td>—</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
 
                     <p id="statusMessage" class="rates-status-message" role="status" aria-live="polite">

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,12 @@ h2 {
     margin-top: 0;
 }
 
+h3 {
+    color: var(--primary-dark);
+    margin-top: 2.5rem;
+    margin-bottom: 0.5rem;
+}
+
 a {
     color: var(--primary-dark);
 }
@@ -250,6 +256,43 @@ a {
 
 .rates-table tbody tr:nth-child(even) {
     background: rgba(138, 182, 255, 0.08);
+}
+
+.historical-section {
+    margin-top: 2rem;
+}
+
+.historical-description {
+    margin: 0.5rem 0 1rem;
+    font-size: 0.95rem;
+    color: rgba(47, 58, 74, 0.85);
+}
+
+.historical-rates-table thead th {
+    white-space: nowrap;
+}
+
+.rate-change {
+    font-weight: 600;
+}
+
+.rate-change-positive {
+    color: #2e8b57;
+}
+
+.rate-change-negative {
+    color: #d35454;
+}
+
+.rate-change-neutral {
+    color: rgba(47, 58, 74, 0.8);
+}
+
+.rates-empty-row td {
+    text-align: center;
+    padding: 1.25rem;
+    color: rgba(47, 58, 74, 0.7);
+    font-style: italic;
 }
 
 .rates-row-error td {


### PR DESCRIPTION
## Summary
- fetch two weeks of USD/JPY and EUR/JPY data from the Frankfurter timeseries API alongside the latest quotes
- render a historical table showing daily rates and percentage change versus the prior business day
- update copy and styling so the new historical section matches the rest of the site

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8f9961e588327ba31db567ffdddca