### PR TITLE
Shift layout palette toward soft greys

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,10 @@
 :root {
-    --primary: #8ab6ff;
-    --primary-dark: #699cf5;
-    --primary-light: #c2dcff;
-    --background: #f4f8ff;
-    --surface: rgba(255, 255, 255, 0.9);
-    --text: #2f3a4a;
+    --primary: #b9bec9;
+    --primary-dark: #858b98;
+    --primary-light: #e1e4ea;
+    --background: #f5f6f8;
+    --surface: rgba(255, 255, 255, 0.92);
+    --text: #2f333a;
 }
 
 * {
@@ -14,22 +14,24 @@
 body {
     font-family: 'Roboto', sans-serif;
     margin: 0;
-    background: linear-gradient(180deg, #fdf8ff 0%, var(--background) 50%, #f0f6ff 100%);
+    background: linear-gradient(180deg, #fafbfc 0%, var(--background) 55%, #eef0f4 100%);
     color: var(--text);
     line-height: 1.6;
 }
 
 header {
-    background: linear-gradient(135deg, var(--primary-light), var(--primary-dark));
-    color: #fff;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(236, 238, 243, 0.92) 70%, rgba(236, 238, 243, 0));
+    color: var(--text);
     padding: 2.5rem 1rem;
     text-align: center;
-    box-shadow: 0 10px 25px rgba(106, 156, 245, 0.25);
+    box-shadow: none;
+    border-bottom: none;
 }
 
 header h1 {
     margin: 0;
     font-weight: 700;
+    color: var(--primary-dark);
 }
 
 nav {
@@ -37,15 +39,16 @@ nav {
 }
 
 nav a {
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(47, 58, 74, 0.75);
     text-decoration: none;
     margin: 0 0.5rem;
     font-weight: 300;
-    transition: opacity 0.3s ease;
+    transition: color 0.3s ease, opacity 0.3s ease;
 }
 
 nav a:hover {
-    opacity: 0.75;
+    color: var(--primary-dark);
+    opacity: 1;
 }
 
 main {
@@ -56,10 +59,10 @@ main {
 
 section {
     padding: 2.5rem;
-    background: linear-gradient(145deg, var(--surface), rgba(238, 244, 255, 0.85));
+    background: linear-gradient(145deg, var(--surface), rgba(240, 241, 245, 0.85));
     border-radius: 20px;
-    box-shadow: 0 12px 30px rgba(138, 182, 255, 0.25);
-    border: 1px solid rgba(138, 182, 255, 0.3);
+    box-shadow: 0 12px 30px rgba(81, 86, 98, 0.14);
+    border: 1px solid rgba(133, 139, 152, 0.18);
 }
 
 .tab-container {
@@ -82,13 +85,13 @@ section {
     font-size: 1rem;
     font-weight: 500;
     cursor: pointer;
-    box-shadow: 0 6px 15px rgba(138, 182, 255, 0.3);
+    box-shadow: 0 6px 15px rgba(116, 122, 136, 0.22);
     transition: all 0.3s ease;
 }
 
 .tab-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 8px 20px rgba(106, 156, 245, 0.4);
+    box-shadow: 0 8px 20px rgba(101, 106, 120, 0.32);
 }
 
 .tab-button.active {
@@ -168,7 +171,7 @@ a {
 .header-subtitle {
     margin-top: 0.75rem;
     font-weight: 300;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(47, 58, 74, 0.65);
 }
 
 .rates-meta {
@@ -182,9 +185,9 @@ a {
 .rates-meta-item {
     padding: 0.75rem 1rem;
     border-radius: 12px;
-    border: 1px solid rgba(138, 182, 255, 0.3);
+    border: 1px solid rgba(133, 139, 152, 0.2);
     background: rgba(255, 255, 255, 0.9);
-    box-shadow: 0 6px 18px rgba(138, 182, 255, 0.2);
+    box-shadow: 0 6px 18px rgba(81, 86, 98, 0.16);
     min-width: 180px;
 }
 
@@ -211,28 +214,28 @@ a {
     font-size: 1rem;
     font-weight: 600;
     cursor: pointer;
-    box-shadow: 0 8px 20px rgba(106, 156, 245, 0.35);
+    box-shadow: 0 8px 20px rgba(101, 106, 120, 0.3);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
 .refresh-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 10px 24px rgba(106, 156, 245, 0.45);
+    box-shadow: 0 10px 24px rgba(101, 106, 120, 0.36);
 }
 
 .refresh-button:disabled {
     opacity: 0.65;
     cursor: not-allowed;
     transform: none;
-    box-shadow: 0 4px 12px rgba(138, 182, 255, 0.2);
+    box-shadow: 0 4px 12px rgba(81, 86, 98, 0.16);
 }
 
 .rates-table-wrapper {
     margin-top: 1.25rem;
     overflow-x: auto;
     border-radius: 16px;
-    border: 1px solid rgba(138, 182, 255, 0.3);
-    box-shadow: 0 10px 25px rgba(138, 182, 255, 0.25);
+    border: 1px solid rgba(133, 139, 152, 0.2);
+    box-shadow: 0 10px 25px rgba(81, 86, 98, 0.18);
     background: rgba(255, 255, 255, 0.95);
 }
 
@@ -255,7 +258,7 @@ a {
 }
 
 .rates-table tbody tr:nth-child(even) {
-    background: rgba(138, 182, 255, 0.08);
+    background: rgba(135, 140, 151, 0.1);
 }
 
 .historical-section {
@@ -315,9 +318,10 @@ a {
 footer {
     text-align: center;
     padding: 1.5rem 1rem;
-    background: linear-gradient(135deg, var(--primary), var(--primary-dark));
-    color: #fff;
-    box-shadow: 0 -6px 20px rgba(106, 156, 245, 0.2);
+    background: linear-gradient(180deg, rgba(232, 234, 239, 0), rgba(232, 234, 239, 0.92) 60%, rgba(255, 255, 255, 0.96) 100%);
+    color: rgba(47, 58, 74, 0.85);
+    border-top: none;
+    box-shadow: none;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- swap the blue theme tokens and shadows for neutral grey values across the layout
- let the header and footer fade into the page background to soften the boundary with the content

## Testing
- not run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68c92c52ce10832798dbf919c2cc2dc1