### PR TITLE
Tighten header/footer spacing and adjust background gradient

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@
 body {
     font-family: 'Roboto', sans-serif;
     margin: 0;
-    background: linear-gradient(180deg, #fafbfc 0%, var(--background) 55%, #eef0f4 100%);
+    background: linear-gradient(180deg, #edeff3 0%, #ffffff 45%, #e2e6ed 100%);
     color: var(--text);
     line-height: 1.6;
 }
@@ -22,7 +22,7 @@ body {
 header {
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(236, 238, 243, 0.92) 70%, rgba(236, 238, 243, 0));
     color: var(--text);
-    padding: 2.5rem 1rem;
+    padding: 1.6rem 1rem 1.4rem;
     text-align: center;
     box-shadow: none;
     border-bottom: none;
@@ -317,7 +317,7 @@ a {
 
 footer {
     text-align: center;
-    padding: 1.5rem 1rem;
+    padding: 1rem 1rem 1.2rem;
     background: linear-gradient(180deg, rgba(232, 234, 239, 0), rgba(232, 234, 239, 0.92) 60%, rgba(255, 255, 255, 0.96) 100%);
     color: rgba(47, 58, 74, 0.85);
     border-top: none;


### PR DESCRIPTION
## Summary
- reduce vertical padding in the header and footer so they take up less height
- refresh the page background with a gray-to-white gradient to better delineate content areas

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c92fceecbc832794a53227517b3de5