### PR TITLE
Replace cube with miniature skyline in 3D tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,17 +89,17 @@
                 <div class="tab-content" id="tab-3d">
                     <h2>3D Preview</h2>
                     <p>
-                        Experience a softly lit 3D cube rendered directly in your browser. The view loads on demand so the resources
-                        are only used when you explore this tab.
+                        Take a tour of a softly lit miniature skyline rendered directly in your browser. The scene loads on demand so
+                        the resources are only used when you explore this tab.
                     </p>
                     <div class="three-d-wrapper" id="threeWrapper">
                         <div class="three-d-status" id="threeStatus" role="status" aria-live="polite">
-                            The 3D preview starts loading as soon as you open this tab.
+                            The city preview starts loading as soon as you open this tab.
                         </div>
                         <canvas
                             id="threeCanvas"
                             class="three-d-canvas"
-                            aria-label="Rotating cube 3D visualization"
+                            aria-label="Rotating city skyline 3D visualization"
                             role="img"
                         ></canvas>
                     </div>


### PR DESCRIPTION
## Summary
- generate WebGL geometry programmatically to render a cluster of buildings and a ground plane
- update 3D tab copy and status messaging to describe the skyline scene
- adjust accessibility text to reflect the new miniature city preview

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cdfc936c4c8327bb8710ae863386b6