### PR TITLE
Enhance skyline detail and static camera

### DIFF
--- a/script.js
+++ b/script.js
@@ -368,108 +368,866 @@ document.addEventListener('DOMContentLoaded', () => {
                             }
                         };
 
+                const addFacadeGrid = ({
+                    orientation,
+                    x,
+                    z,
+                    width,
+                    depth,
+                    baseHeight = 0,
+                    height,
+                    rows,
+                    columns,
+                    insetRatio = 0.12,
+                    verticalInsetRatio = insetRatio,
+                    gapRatio = 0.12,
+                    color,
+                    depthOffset = 0.003,
+                }) => {
+                    const safeRows = Math.max(1, Math.floor(rows || 0));
+                    const safeColumns = Math.max(1, Math.floor(columns || 0));
+
+                    if (!height || !width || !depth) {
+                        return;
+                    }
+
+                    const verticalInset = Math.max(0, height * verticalInsetRatio);
+                    const verticalSpan = height - verticalInset * 2;
+                    if (verticalSpan <= 0) {
+                        return;
+                    }
+
+                    const verticalGap =
+                        safeRows > 1 ? Math.max(0, verticalSpan * gapRatio) / (safeRows - 1) : 0;
+                    const panelHeight =
+                        (verticalSpan - verticalGap * (safeRows - 1)) / safeRows;
+                    if (panelHeight <= 0) {
+                        return;
+                    }
+
+                    const halfWidth = width / 2;
+                    const halfDepth = depth / 2;
+                    const startY = baseHeight + verticalInset;
+
+                    const addPanels = (orientationName) => {
+                        const orientationLower = String(orientationName || '').toLowerCase();
+
+                        if (orientationLower === 'front' || orientationLower === 'back') {
+                            const horizontalInset = Math.max(0, width * insetRatio);
+                            const horizontalSpan = width - horizontalInset * 2;
+                            if (horizontalSpan <= 0) {
+                                return;
+                            }
+
+                            const horizontalGap =
+                                safeColumns > 1
+                                    ? Math.max(0, horizontalSpan * gapRatio) / (safeColumns - 1)
+                                    : 0;
+                            const panelWidth =
+                                (horizontalSpan - horizontalGap * (safeColumns - 1)) / safeColumns;
+                            if (panelWidth <= 0) {
+                                return;
+                            }
+
+                            const startX = x - halfWidth + horizontalInset;
+                            const zPlane =
+                                z + (orientationLower === 'front' ? halfDepth + depthOffset : -halfDepth - depthOffset);
+                            const normal = orientationLower === 'front' ? [0, 0, 1] : [0, 0, -1];
+                            const order = orientationLower === 'front' ? [0, 1, 2, 3] : [0, 3, 2, 1];
+
+                            for (let row = 0; row < safeRows; row += 1) {
+                                const y0 = startY + row * (panelHeight + verticalGap);
+                                const y1 = y0 + panelHeight;
+                                for (let column = 0; column < safeColumns; column += 1) {
+                                    const x0 = startX + column * (panelWidth + horizontalGap);
+                                    const x1 = x0 + panelWidth;
+                                    const vertices = [
+                                        [x0, y0, zPlane],
+                                        [x1, y0, zPlane],
+                                        [x1, y1, zPlane],
+                                        [x0, y1, zPlane],
+                                    ];
+
+                                    addFace(
+                                        vertices[order[0]],
+                                        vertices[order[1]],
+                                        vertices[order[2]],
+                                        vertices[order[3]],
+                                        normal,
+                                        color
+                                    );
+                                }
+                            }
+                        } else if (orientationLower === 'left' || orientationLower === 'right') {
+                            const horizontalInset = Math.max(0, depth * insetRatio);
+                            const horizontalSpan = depth - horizontalInset * 2;
+                            if (horizontalSpan <= 0) {
+                                return;
+                            }
+
+                            const horizontalGap =
+                                safeColumns > 1
+                                    ? Math.max(0, horizontalSpan * gapRatio) / (safeColumns - 1)
+                                    : 0;
+                            const panelDepth =
+                                (horizontalSpan - horizontalGap * (safeColumns - 1)) / safeColumns;
+                            if (panelDepth <= 0) {
+                                return;
+                            }
+
+                            const startZ = z - halfDepth + horizontalInset;
+                            const xPlane =
+                                x + (orientationLower === 'right' ? halfWidth + depthOffset : -halfWidth - depthOffset);
+                            const normal = orientationLower === 'right' ? [1, 0, 0] : [-1, 0, 0];
+                            const order = orientationLower === 'right' ? [0, 1, 2, 3] : [0, 3, 2, 1];
+
+                            for (let row = 0; row < safeRows; row += 1) {
+                                const y0 = startY + row * (panelHeight + verticalGap);
+                                const y1 = y0 + panelHeight;
+                                for (let column = 0; column < safeColumns; column += 1) {
+                                    const z0 = startZ + column * (panelDepth + horizontalGap);
+                                    const z1 = z0 + panelDepth;
+                                    const vertices = [
+                                        [xPlane, y0, z0],
+                                        [xPlane, y0, z1],
+                                        [xPlane, y1, z1],
+                                        [xPlane, y1, z0],
+                                    ];
+
+                                    addFace(
+                                        vertices[order[0]],
+                                        vertices[order[1]],
+                                        vertices[order[2]],
+                                        vertices[order[3]],
+                                        normal,
+                                        color
+                                    );
+                                }
+                            }
+                        }
+                    };
+
+                    addPanels(orientation);
+                };
+
+                const applyFacades = (buildingConfig, facades = []) => {
+                    facades.forEach((facade) => {
+                        addFacadeGrid({
+                            orientation: facade.orientation,
+                            x: buildingConfig.x,
+                            z: buildingConfig.z,
+                            width: buildingConfig.width,
+                            depth: buildingConfig.depth,
+                            baseHeight: facade.baseHeight ?? buildingConfig.baseHeight ?? 0,
+                            height: facade.height ?? buildingConfig.height,
+                            rows: facade.rows,
+                            columns: facade.columns,
+                            insetRatio: facade.insetRatio ?? 0.12,
+                            verticalInsetRatio: facade.verticalInsetRatio ?? facade.insetRatio ?? 0.12,
+                            gapRatio: facade.gapRatio ?? 0.12,
+                            color: facade.color,
+                            depthOffset: facade.depthOffset ?? 0.003,
+                        });
+                    });
+                };
+
                         addGround(8, -0.05, [0.18, 0.22, 0.28]);
 
-                        addBuilding({
+                        const centralFoundation = {
                             x: 0,
                             z: 0,
-                            width: 1.2,
-                            depth: 1.2,
-                            height: 2.6,
+                            width: 1.4,
+                            depth: 1.4,
+                            height: 0.3,
+                            sideColor: [0.36, 0.46, 0.64],
+                            roofColor: [0.48, 0.58, 0.72],
+                            baseColor: [0.28, 0.36, 0.52],
+                        };
+                        addBuilding(centralFoundation);
+
+                        const centralMain = {
+                            x: 0,
+                            z: 0,
+                            width: 1.1,
+                            depth: 1.1,
+                            baseHeight: 0.3,
+                            height: 2.3,
                             sideColor: [0.52, 0.67, 0.88],
                             roofColor: [0.74, 0.82, 0.94],
-                            baseColor: [0.4, 0.53, 0.72],
-                        });
-                        addBuilding({
+                            baseColor: [0.41, 0.54, 0.73],
+                        };
+                        addBuilding(centralMain);
+                        applyFacades(centralMain, [
+                            {
+                                orientation: 'front',
+                                rows: 5,
+                                columns: 3,
+                                color: [0.82, 0.89, 0.98],
+                                insetRatio: 0.14,
+                                verticalInsetRatio: 0.12,
+                                gapRatio: 0.12,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 5,
+                                columns: 3,
+                                color: [0.82, 0.89, 0.98],
+                                insetRatio: 0.14,
+                                verticalInsetRatio: 0.12,
+                                gapRatio: 0.12,
+                            },
+                            {
+                                orientation: 'left',
+                                rows: 5,
+                                columns: 2,
+                                color: [0.8, 0.88, 0.97],
+                                insetRatio: 0.16,
+                                verticalInsetRatio: 0.12,
+                                gapRatio: 0.12,
+                            },
+                            {
+                                orientation: 'right',
+                                rows: 5,
+                                columns: 2,
+                                color: [0.8, 0.88, 0.97],
+                                insetRatio: 0.16,
+                                verticalInsetRatio: 0.12,
+                                gapRatio: 0.12,
+                            },
+                        ]);
+
+
+                        const centralTerrace = {
                             x: 0,
                             z: 0,
-                            width: 0.6,
-                            depth: 0.6,
-                            height: 1.1,
-                            baseHeight: 2.6,
+                            width: 0.94,
+                            depth: 0.94,
+                            baseHeight: centralMain.baseHeight + centralMain.height,
+                            height: 0.2,
                             sideColor: [0.66, 0.79, 0.94],
                             roofColor: [0.82, 0.89, 0.97],
+                            baseColor: [0.56, 0.69, 0.89],
+                        };
+                        addBuilding(centralTerrace);
+
+                        const centralUpper = {
+                            x: 0,
+                            z: 0,
+                            width: 0.55,
+                            depth: 0.55,
+                            baseHeight: centralTerrace.baseHeight + centralTerrace.height,
+                            height: 0.95,
+                            sideColor: [0.66, 0.79, 0.94],
+                            roofColor: [0.85, 0.91, 0.98],
                             includeBottom: false,
+                        };
+                        addBuilding(centralUpper);
+                        applyFacades(centralUpper, [
+                            {
+                                orientation: 'front',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.88, 0.93, 0.99],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.12,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.88, 0.93, 0.99],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.12,
+                            },
+                        ]);
+
+                        const centralSpire = {
+                            x: 0,
+                            z: 0,
+                            width: 0.14,
+                            depth: 0.14,
+                            baseHeight: centralUpper.baseHeight + centralUpper.height,
+                            height: 0.38,
+                            sideColor: [0.92, 0.95, 0.99],
+                            roofColor: [0.97, 0.98, 1.0],
+                            includeBottom: false,
+                        };
+                        addBuilding(centralSpire);
+
+                        const rooftopUnits = [
+                            { x: -0.3, z: 0.22, width: 0.26, depth: 0.3 },
+                            { x: 0.32, z: -0.18, width: 0.28, depth: 0.24 },
+                        ];
+                        rooftopUnits.forEach((unit) => {
+                            addBuilding({
+                                ...unit,
+                                baseHeight: centralTerrace.baseHeight + centralTerrace.height,
+                                height: 0.16,
+                                sideColor: [0.41, 0.49, 0.58],
+                                roofColor: [0.55, 0.62, 0.7],
+                                baseColor: [0.35, 0.42, 0.52],
+                                includeBottom: false,
+                            });
                         });
-                        addBuilding({
+
+
+                        const westBlockBase = {
                             x: -1.7,
                             z: 0.3,
-                            width: 0.9,
-                            depth: 1.0,
-                            height: 1.7,
+                            width: 1.0,
+                            depth: 1.05,
+                            height: 0.22,
+                            sideColor: [0.32, 0.45, 0.64],
+                            roofColor: [0.45, 0.56, 0.72],
+                            baseColor: [0.25, 0.35, 0.52],
+                        };
+                        addBuilding(westBlockBase);
+
+                        const westBlockMain = {
+                            x: -1.7,
+                            z: 0.3,
+                            width: 0.82,
+                            depth: 0.85,
+                            baseHeight: westBlockBase.height,
+                            height: 1.55,
                             sideColor: [0.44, 0.58, 0.78],
                             roofColor: [0.62, 0.72, 0.86],
-                            baseColor: [0.32, 0.45, 0.64],
+                            baseColor: [0.34, 0.47, 0.66],
+                        };
+                        addBuilding(westBlockMain);
+                        applyFacades(westBlockMain, [
+                            {
+                                orientation: 'front',
+                                rows: 4,
+                                columns: 2,
+                                color: [0.78, 0.86, 0.96],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 4,
+                                columns: 2,
+                                color: [0.78, 0.86, 0.96],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'left',
+                                rows: 4,
+                                columns: 2,
+                                color: [0.76, 0.84, 0.94],
+                                insetRatio: 0.2,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                        ]);
+
+                        const westBlockTerrace = {
+                            x: -1.7,
+                            z: 0.3,
+                            width: 0.68,
+                            depth: 0.7,
+                            baseHeight: westBlockMain.baseHeight + westBlockMain.height,
+                            height: 0.2,
+                            sideColor: [0.55, 0.67, 0.84],
+                            roofColor: [0.71, 0.79, 0.9],
+                            baseColor: [0.45, 0.57, 0.76],
+                        };
+                        addBuilding(westBlockTerrace);
+
+                        [
+                            { x: -1.92, z: 0.32, width: 0.2, depth: 0.34 },
+                            { x: -1.48, z: 0.46, width: 0.22, depth: 0.22 },
+                        ].forEach((unit) => {
+                            addBuilding({
+                                ...unit,
+                                baseHeight: westBlockTerrace.baseHeight + westBlockTerrace.height,
+                                height: 0.16,
+                                sideColor: [0.39, 0.47, 0.56],
+                                roofColor: [0.52, 0.6, 0.68],
+                                baseColor: [0.32, 0.4, 0.49],
+                                includeBottom: false,
+                            });
                         });
-                        addBuilding({
+
+
+                        const eastBlockBase = {
                             x: 1.8,
                             z: -0.4,
-                            width: 1.2,
-                            depth: 0.8,
-                            height: 1.5,
+                            width: 1.3,
+                            depth: 0.95,
+                            height: 0.25,
+                            sideColor: [0.38, 0.48, 0.64],
+                            roofColor: [0.5, 0.6, 0.74],
+                            baseColor: [0.3, 0.38, 0.52],
+                        };
+                        addBuilding(eastBlockBase);
+
+                        const eastBlockMain = {
+                            x: 1.8,
+                            z: -0.4,
+                            width: 1.05,
+                            depth: 0.72,
+                            baseHeight: eastBlockBase.height,
+                            height: 1.25,
                             sideColor: [0.57, 0.69, 0.85],
                             roofColor: [0.74, 0.82, 0.93],
                             baseColor: [0.46, 0.59, 0.78],
+                        };
+                        addBuilding(eastBlockMain);
+                        applyFacades(eastBlockMain, [
+                            {
+                                orientation: 'front',
+                                rows: 3,
+                                columns: 3,
+                                color: [0.81, 0.88, 0.97],
+                                insetRatio: 0.14,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 3,
+                                columns: 3,
+                                color: [0.81, 0.88, 0.97],
+                                insetRatio: 0.14,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'right',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.78, 0.86, 0.96],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'left',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.78, 0.86, 0.96],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                        ]);
+
+                        const eastBlockTier = {
+                            x: 1.8,
+                            z: -0.4,
+                            width: 0.78,
+                            depth: 0.58,
+                            baseHeight: eastBlockMain.baseHeight + eastBlockMain.height,
+                            height: 0.28,
+                            sideColor: [0.63, 0.75, 0.9],
+                            roofColor: [0.8, 0.87, 0.96],
+                            baseColor: [0.54, 0.66, 0.84],
+                        };
+                        addBuilding(eastBlockTier);
+
+                        addBuilding({
+                            x: 1.52,
+                            z: -0.35,
+                            width: 0.3,
+                            depth: 0.4,
+                            baseHeight: eastBlockTier.baseHeight + eastBlockTier.height,
+                            height: 0.22,
+                            sideColor: [0.45, 0.55, 0.68],
+                            roofColor: [0.6, 0.68, 0.78],
+                            baseColor: [0.38, 0.47, 0.58],
+                            includeBottom: false,
                         });
                         addBuilding({
+                            x: 2.06,
+                            z: -0.46,
+                            width: 0.26,
+                            depth: 0.36,
+                            baseHeight: eastBlockTier.baseHeight + eastBlockTier.height,
+                            height: 0.18,
+                            sideColor: [0.47, 0.57, 0.7],
+                            roofColor: [0.62, 0.7, 0.8],
+                            baseColor: [0.4, 0.48, 0.6],
+                            includeBottom: false,
+                        });
+
+
+                        const northBlockBase = {
                             x: -0.6,
                             z: 1.9,
-                            width: 0.8,
-                            depth: 1.3,
-                            height: 1.2,
+                            width: 0.92,
+                            depth: 1.4,
+                            height: 0.22,
+                            sideColor: [0.38, 0.5, 0.68],
+                            roofColor: [0.5, 0.6, 0.74],
+                            baseColor: [0.3, 0.4, 0.56],
+                        };
+                        addBuilding(northBlockBase);
+
+                        const northBlockMain = {
+                            x: -0.6,
+                            z: 1.9,
+                            width: 0.78,
+                            depth: 1.18,
+                            baseHeight: northBlockBase.height,
+                            height: 1.05,
                             sideColor: [0.54, 0.66, 0.82],
                             roofColor: [0.7, 0.79, 0.9],
                             baseColor: [0.42, 0.53, 0.7],
+                        };
+                        addBuilding(northBlockMain);
+                        applyFacades(northBlockMain, [
+                            {
+                                orientation: 'front',
+                                rows: 3,
+                                columns: 3,
+                                color: [0.8, 0.87, 0.96],
+                                insetRatio: 0.16,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 3,
+                                columns: 3,
+                                color: [0.8, 0.87, 0.96],
+                                insetRatio: 0.16,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'left',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.78, 0.85, 0.94],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.14,
+                            },
+                        ]);
+
+                        const northRoof = {
+                            x: -0.6,
+                            z: 1.9,
+                            width: 0.84,
+                            depth: 1.24,
+                            baseHeight: northBlockMain.baseHeight + northBlockMain.height,
+                            height: 0.18,
+                            sideColor: [0.62, 0.74, 0.88],
+                            roofColor: [0.76, 0.83, 0.92],
+                            baseColor: [0.5, 0.62, 0.8],
+                        };
+                        addBuilding(northRoof);
+
+                        [
+                            { x: -0.84, z: 1.78, width: 0.28, depth: 0.3 },
+                            { x: -0.36, z: 2.04, width: 0.26, depth: 0.32 },
+                        ].forEach((green) => {
+                            addBuilding({
+                                ...green,
+                                baseHeight: northRoof.baseHeight + northRoof.height,
+                                height: 0.12,
+                                sideColor: [0.33, 0.46, 0.42],
+                                roofColor: [0.42, 0.56, 0.5],
+                                baseColor: [0.28, 0.38, 0.35],
+                                includeBottom: false,
+                            });
                         });
-                        addBuilding({
+
+
+                        const northeastBase = {
                             x: 1.2,
                             z: 1.6,
-                            width: 0.7,
-                            depth: 0.7,
-                            height: 1.9,
+                            width: 0.82,
+                            depth: 0.82,
+                            height: 0.24,
+                            sideColor: [0.42, 0.55, 0.74],
+                            roofColor: [0.55, 0.66, 0.82],
+                            baseColor: [0.34, 0.45, 0.62],
+                        };
+                        addBuilding(northeastBase);
+
+                        const northeastMain = {
+                            x: 1.2,
+                            z: 1.6,
+                            width: 0.68,
+                            depth: 0.68,
+                            baseHeight: northeastBase.height,
+                            height: 1.7,
                             sideColor: [0.6, 0.72, 0.9],
                             roofColor: [0.76, 0.84, 0.95],
                             baseColor: [0.48, 0.59, 0.78],
-                        });
+                        };
+                        addBuilding(northeastMain);
+                        applyFacades(northeastMain, [
+                            {
+                                orientation: 'front',
+                                rows: 5,
+                                columns: 2,
+                                color: [0.84, 0.9, 0.98],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.12,
+                                gapRatio: 0.12,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 5,
+                                columns: 2,
+                                color: [0.84, 0.9, 0.98],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.12,
+                                gapRatio: 0.12,
+                            },
+                        ]);
+
+                        const northeastCrown = {
+                            x: 1.2,
+                            z: 1.6,
+                            width: 0.5,
+                            depth: 0.5,
+                            baseHeight: northeastMain.baseHeight + northeastMain.height,
+                            height: 0.22,
+                            sideColor: [0.68, 0.79, 0.92],
+                            roofColor: [0.82, 0.88, 0.96],
+                            baseColor: [0.56, 0.68, 0.84],
+                        };
+                        addBuilding(northeastCrown);
+
                         addBuilding({
+                            x: 1.2,
+                            z: 1.6,
+                            width: 0.18,
+                            depth: 0.18,
+                            baseHeight: northeastCrown.baseHeight + northeastCrown.height,
+                            height: 0.32,
+                            sideColor: [0.9, 0.94, 0.99],
+                            roofColor: [0.97, 0.98, 1.0],
+                            includeBottom: false,
+                        });
+
+
+                        const southwestBase = {
+                            x: -1.1,
+                            z: -1.6,
+                            width: 0.72,
+                            depth: 1.18,
+                            height: 0.22,
+                            sideColor: [0.34, 0.46, 0.62],
+                            roofColor: [0.46, 0.56, 0.72],
+                            baseColor: [0.26, 0.36, 0.52],
+                        };
+                        addBuilding(southwestBase);
+
+                        const southwestMain = {
                             x: -1.1,
                             z: -1.6,
                             width: 0.6,
-                            depth: 1.1,
-                            height: 1.0,
+                            depth: 1.0,
+                            baseHeight: southwestBase.height,
+                            height: 0.95,
                             sideColor: [0.47, 0.6, 0.78],
                             roofColor: [0.66, 0.76, 0.88],
                             baseColor: [0.35, 0.48, 0.66],
+                        };
+                        addBuilding(southwestMain);
+                        applyFacades(southwestMain, [
+                            {
+                                orientation: 'front',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.78, 0.86, 0.95],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.15,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 3,
+                                columns: 2,
+                                color: [0.78, 0.86, 0.95],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.18,
+                                gapRatio: 0.15,
+                            },
+                        ]);
+
+                        addBuilding({
+                            x: -1.1,
+                            z: -1.6,
+                            width: 0.66,
+                            depth: 1.06,
+                            baseHeight: southwestMain.baseHeight + southwestMain.height,
+                            height: 0.14,
+                            sideColor: [0.56, 0.68, 0.84],
+                            roofColor: [0.7, 0.79, 0.9],
+                            baseColor: [0.44, 0.56, 0.74],
                         });
+
+
+                        const southPromenade = {
+                            x: 0.9,
+                            z: -1.8,
+                            width: 2.4,
+                            depth: 0.5,
+                            height: 0.18,
+                            sideColor: [0.33, 0.38, 0.45],
+                            roofColor: [0.46, 0.5, 0.56],
+                            baseColor: [0.26, 0.3, 0.36],
+                        };
+                        addBuilding(southPromenade);
+
                         addBuilding({
                             x: 0.9,
                             z: -1.8,
                             width: 2.4,
                             depth: 0.5,
-                            height: 0.25,
-                            sideColor: [0.33, 0.38, 0.45],
-                            roofColor: [0.46, 0.5, 0.56],
-                            baseColor: [0.26, 0.3, 0.36],
+                            baseHeight: southPromenade.height,
+                            height: 0.08,
+                            sideColor: [0.4, 0.45, 0.52],
+                            roofColor: [0.52, 0.57, 0.62],
+                            baseColor: [0.32, 0.36, 0.43],
                         });
-                        addBuilding({
+
+                        [
+                            { x: 0.15, z: -1.8, width: 0.18, depth: 0.18 },
+                            { x: 1.65, z: -1.8, width: 0.18, depth: 0.18 },
+                        ].forEach((lamp) => {
+                            addBuilding({
+                                ...lamp,
+                                baseHeight: southPromenade.height + 0.08,
+                                height: 0.3,
+                                sideColor: [0.62, 0.72, 0.86],
+                                roofColor: [0.78, 0.84, 0.92],
+                                baseColor: [0.5, 0.6, 0.74],
+                                includeBottom: false,
+                            });
+                        });
+
+
+                        const farWestBase = {
+                            x: -2.2,
+                            z: -0.8,
+                            width: 0.6,
+                            depth: 0.6,
+                            height: 0.22,
+                            sideColor: [0.42, 0.54, 0.72],
+                            roofColor: [0.55, 0.66, 0.82],
+                            baseColor: [0.34, 0.45, 0.64],
+                        };
+                        addBuilding(farWestBase);
+
+                        const farWestTower = {
                             x: -2.2,
                             z: -0.8,
                             width: 0.5,
                             depth: 0.5,
-                            height: 1.5,
+                            baseHeight: farWestBase.height,
+                            height: 1.4,
                             sideColor: [0.62, 0.74, 0.9],
                             roofColor: [0.78, 0.86, 0.96],
                             baseColor: [0.5, 0.62, 0.78],
-                        });
+                        };
+                        addBuilding(farWestTower);
+                        applyFacades(farWestTower, [
+                            {
+                                orientation: 'front',
+                                rows: 4,
+                                columns: 2,
+                                color: [0.88, 0.93, 0.99],
+                                insetRatio: 0.18,
+                                verticalInsetRatio: 0.14,
+                                gapRatio: 0.12,
+                            },
+                        ]);
+
                         addBuilding({
+                            x: -2.2,
+                            z: -0.8,
+                            width: 0.32,
+                            depth: 0.32,
+                            baseHeight: farWestTower.baseHeight + farWestTower.height,
+                            height: 0.24,
+                            sideColor: [0.74, 0.83, 0.95],
+                            roofColor: [0.86, 0.91, 0.98],
+                            baseColor: [0.63, 0.74, 0.9],
+                        });
+
+
+                        const eastParkBase = {
                             x: 2.1,
                             z: 1.1,
-                            width: 0.9,
-                            depth: 0.6,
-                            height: 1.3,
+                            width: 1.05,
+                            depth: 0.7,
+                            height: 0.24,
+                            sideColor: [0.36, 0.48, 0.66],
+                            roofColor: [0.48, 0.58, 0.74],
+                            baseColor: [0.28, 0.38, 0.56],
+                        };
+                        addBuilding(eastParkBase);
+
+                        const eastParkMain = {
+                            x: 2.1,
+                            z: 1.1,
+                            width: 0.92,
+                            depth: 0.58,
+                            baseHeight: eastParkBase.height,
+                            height: 1.08,
                             sideColor: [0.49, 0.63, 0.82],
                             roofColor: [0.68, 0.78, 0.9],
                             baseColor: [0.36, 0.49, 0.68],
+                        };
+                        addBuilding(eastParkMain);
+                        applyFacades(eastParkMain, [
+                            {
+                                orientation: 'front',
+                                rows: 4,
+                                columns: 2,
+                                color: [0.79, 0.87, 0.96],
+                                insetRatio: 0.16,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                            {
+                                orientation: 'back',
+                                rows: 4,
+                                columns: 2,
+                                color: [0.79, 0.87, 0.96],
+                                insetRatio: 0.16,
+                                verticalInsetRatio: 0.16,
+                                gapRatio: 0.14,
+                            },
+                        ]);
+
+                        const eastParkRoof = {
+                            x: 2.1,
+                            z: 1.1,
+                            width: 0.98,
+                            depth: 0.64,
+                            baseHeight: eastParkMain.baseHeight + eastParkMain.height,
+                            height: 0.16,
+                            sideColor: [0.56, 0.68, 0.84],
+                            roofColor: [0.72, 0.8, 0.9],
+                            baseColor: [0.44, 0.56, 0.74],
+                        };
+                        addBuilding(eastParkRoof);
+
+                        addBuilding({
+                            x: 2.1,
+                            z: 1.1,
+                            width: 0.58,
+                            depth: 0.34,
+                            baseHeight: eastParkRoof.baseHeight + eastParkRoof.height,
+                            height: 0.14,
+                            sideColor: [0.4, 0.52, 0.68],
+                            roofColor: [0.54, 0.64, 0.78],
+                            baseColor: [0.32, 0.42, 0.58],
+                            includeBottom: false,
                         });
 
                         const positions = new Float32Array(positionsArray);
@@ -563,10 +1321,12 @@ document.addEventListener('DOMContentLoaded', () => {
                             gl.viewport(0, 0, canvas.width, canvas.height);
                         };
 
-                        const render = (time) => {
-                            resizeCanvas();
+                        const staticRotation = {
+                            x: (28 * Math.PI) / 180,
+                            y: (32 * Math.PI) / 180,
+                        };
 
-                            const seconds = time * 0.001;
+                        const drawScene = () => {
                             const aspect = canvas.width / canvas.height || 1;
 
                             perspectiveMatrix(
@@ -577,8 +1337,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                 100
                             );
 
-                            rotateXMatrix(rotationX, seconds * 0.85);
-                            rotateYMatrix(rotationY, seconds * 0.6);
+                            rotateXMatrix(rotationX, staticRotation.x);
+                            rotateYMatrix(rotationY, staticRotation.y);
 
                             multiplyMatrices(model, rotationY, rotationX);
                             multiplyMatrices(modelView, view, model);
@@ -589,13 +1349,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
                             gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
                             gl.drawElements(gl.TRIANGLES, indices.length, gl.UNSIGNED_SHORT, 0);
+                        };
 
-                            animationFrameId = requestAnimationFrame(render);
+                        const scheduleDraw = () => {
+                            if (animationFrameId !== null) {
+                                cancelAnimationFrame(animationFrameId);
+                            }
+                            animationFrameId = requestAnimationFrame(() => {
+                                animationFrameId = null;
+                                resizeCanvas();
+                                drawScene();
+                            });
                         };
 
                         resizeCanvas();
-                        window.addEventListener('resize', resizeCanvas);
-                        animationFrameId = requestAnimationFrame(render);
+                        scheduleDraw();
+                        window.addEventListener('resize', scheduleDraw);
 
                         if (status) {
                             status.textContent = '';
@@ -607,7 +1376,9 @@ document.addEventListener('DOMContentLoaded', () => {
                             stop: () => {
                                 if (animationFrameId !== null) {
                                     cancelAnimationFrame(animationFrameId);
+                                    animationFrameId = null;
                                 }
+                                window.removeEventListener('resize', scheduleDraw);
                             },
                         });
                     } catch (error) {


### PR DESCRIPTION
## Summary
- add facade grid helper utilities and use them to add window grids on key towers
- rebuild the skyline with tiered foundations, roof details, and rooftop equipment for a richer profile
- change the WebGL preview to render a static scene and redraw only on resize events

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ce018da92483278ef1e33951ed54d5